### PR TITLE
dodanie zapisywania niektórych analiz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 install: true
 jdk:
-- openjdk10
+- openjdk8
 notifications:
   email:
     recipients:

--- a/src/main/java/com/zpi/Menu.java
+++ b/src/main/java/com/zpi/Menu.java
@@ -1,5 +1,9 @@
 package com.zpi;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.*;
 
 import com.zpi.data.series.NbpSeriesA;
@@ -17,6 +21,7 @@ public class Menu {
     Scanner input = new Scanner(System.in);
     String chosenCurrency, secondChosenCurrency, chosenPeriod, chosenTable, chosenAnalyze;
     Set<String> currency = new HashSet<>();
+    List<String> listToSave = new ArrayList<>();
 
     public Menu() {
         while (true) {
@@ -97,12 +102,12 @@ public class Menu {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu A" +
                             " dla waluty " + chosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
 
-                    NbpSeriesA.analyzeSessions(getNbpSeriesAForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
+                    listToSave = NbpSeriesA.analyzeSessions(getNbpSeriesAForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
                 } else if(chosenAnalyze.equals("2")) {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu A" +
                             " dla waluty " + chosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
 
-                    NbpSeriesA.analyzeStatisticalMeasures(getNbpSeriesAForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
+                    listToSave = NbpSeriesA.analyzeStatisticalMeasures(getNbpSeriesAForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
                 } else if(chosenAnalyze.equals("3")) {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu A" +
                             " dla walut " + chosenCurrency + " i " + secondChosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
@@ -117,12 +122,12 @@ public class Menu {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu B" +
                             " dla waluty " + chosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
 
-                    NbpSeriesB.analyzeSessions(getNbpSeriesBForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
+                    listToSave = NbpSeriesB.analyzeSessions(getNbpSeriesBForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
                 } else if(chosenAnalyze.equals("2")) {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu B" +
                             " dla waluty " + chosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
 
-                    NbpSeriesB.analyzeStatisticalMeasures(getNbpSeriesBForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
+                    listToSave = NbpSeriesB.analyzeStatisticalMeasures(getNbpSeriesBForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
                 } else if(chosenAnalyze.equals("3")) {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu B" +
                             " dla walut " + chosenCurrency + " i " + secondChosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
@@ -137,12 +142,12 @@ public class Menu {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu C" +
                             " dla waluty " + chosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
 
-                    NbpSeriesC.analyzeSessions(getNbpSeriesCForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
+                    listToSave = NbpSeriesC.analyzeSessions(getNbpSeriesCForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
                 } else if(chosenAnalyze.equals("2")) {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu C" +
                             " dla waluty " + chosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
 
-                    NbpSeriesC.analyzeStatisticalMeasures(getNbpSeriesCForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
+                    listToSave = NbpSeriesC.analyzeStatisticalMeasures(getNbpSeriesCForGivenCurrencyFromGivenPeriod(chosenCurrency, amountOfRecords));
                 } else if(chosenAnalyze.equals("3")) {
                     System.out.println("Analiza będzie przeprowadzona dla tabeli kursów walut typu C" +
                             " dla walut " + chosenCurrency + " i " + secondChosenCurrency + " w określonym okresie. Ilość rekordów: " + amountOfRecords);
@@ -173,7 +178,33 @@ public class Menu {
         }
     }
 
+    public void saveResults() {
+        try(FileWriter fw = new FileWriter("results.txt", true);
+                BufferedWriter bw = new BufferedWriter(fw);
+                PrintWriter out = new PrintWriter(bw))
+        {
+            out.println("Analiza typ: " + chosenAnalyze + ", tabela: " + chosenTable + ", okres: "
+                        + chosenPeriod + ", waluta: " + chosenCurrency);
+            for(int i = 0; i < listToSave.size(); i++) {
+                out.println(listToSave.get(i));
+            }
+            out.println("------------------------------------------------");
+        } catch (IOException e) {
+            System.out.println("Blad zapisu");
+        }
+    }
+
     private boolean exit() {
+
+        if(!chosenAnalyze.equals("3")) {
+            System.out.println("Czy chcesz zapisać wyniki ostatniej analizy? T/N");
+            String answer = input.nextLine();
+
+            if (answer.equals("T")) {
+                saveResults();
+            }
+        }
+
         while (true) {
             System.out.println("Czy chcesz ponownie wykonać operację? T/N");
             String result = input.nextLine();

--- a/src/main/java/com/zpi/Methods.java
+++ b/src/main/java/com/zpi/Methods.java
@@ -3,6 +3,8 @@ package com.zpi;
 import org.apache.commons.math3.stat.descriptive.rank.Median;
 
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Methods {
 
@@ -120,17 +122,39 @@ public class Methods {
 
     }
 
-    public static void showResultsOfSessionAnalysis(double[] values) {
-        System.out.println("Ilość sesji wzrostowych wynosi: " + Methods.findAmountOfGrowthSessions(values));
-        System.out.println("Ilość sesji spadkowych wynosi: " + Methods.findAmountOfDownwardSessions(values));
-        System.out.println("Ilość sesji bez zmian wynosi: " + Methods.findAmountOfUnchangedSessions(values));
+    public static List<String> showResultsOfSessionAnalysis(double[] values) {
+        String result1 = "Ilość sesji wzrostowych wynosi: " + Methods.findAmountOfGrowthSessions(values);
+        String result2 = "Ilość sesji spadkowych wynosi: " + Methods.findAmountOfDownwardSessions(values);
+        String result3 = "Ilość sesji bez zmian wynosi: " + Methods.findAmountOfUnchangedSessions(values);
+        System.out.println(result1);
+        System.out.println(result2);
+        System.out.println(result3);
+
+        List<String> results = new ArrayList<>();
+        results.add(result1);
+        results.add(result2);
+        results.add(result3);
+
+        return results;
     }
 
-    public static void showResultsOfStatisticalMeasuresAnalysis(double[] values) {
-        System.out.println("Mediana wynosi: " + Methods.findMedian(values));
-        System.out.println("Dominanta wynosi: " + Methods.findMode(values));
-        System.out.println("Odchylenie standardowe wynosi: " + Methods.findStandardDeviation(values));
-        System.out.println("Współczynnik zmienności wynosi: " + Methods.findCoefficientOfVariation(values));
+    public static List<String> showResultsOfStatisticalMeasuresAnalysis(double[] values) {
+        String result1 = "Mediana wynosi: " + Methods.findMedian(values);
+        String result2 = "Dominanta wynosi: " + Methods.findMode(values);
+        String result3 = "Odchylenie standardowe wynosi: " + Methods.findStandardDeviation(values);
+        String result4 = "Współczynnik zmienności wynosi: " + Methods.findCoefficientOfVariation(values);
+        System.out.println(result1);
+        System.out.println(result2);
+        System.out.println(result3);
+        System.out.println(result4);
+
+        List<String> results = new ArrayList<>();
+        results.add(result1);
+        results.add(result2);
+        results.add(result3);
+        results.add(result4);
+
+        return results;
     }
 
     public static void showCurrencyAndDifference(String currency, double diff) {

--- a/src/main/java/com/zpi/data/series/NbpSeriesA.java
+++ b/src/main/java/com/zpi/data/series/NbpSeriesA.java
@@ -27,16 +27,16 @@ public class NbpSeriesA {
         return rates;
     }
 
-    public static void analyzeStatisticalMeasures(NbpSeriesA nbpSeriesA) {
+    public static List<String> analyzeStatisticalMeasures(NbpSeriesA nbpSeriesA) {
         double[] valuesCurrency = getValuesCurrency(nbpSeriesA);
 
-        Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrency);
+        return Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrency);
     }
 
-    public static void analyzeSessions(NbpSeriesA nbpSeriesA) {
+    public static List<String> analyzeSessions(NbpSeriesA nbpSeriesA) {
         double[] valuesCurrency = getValuesCurrency(nbpSeriesA);
 
-        Methods.showResultsOfSessionAnalysis(valuesCurrency);
+        return Methods.showResultsOfSessionAnalysis(valuesCurrency);
     }
 
     public static void compareTwoCurrencies(NbpSeriesA nbpSeriesA1, String currency1, NbpSeriesA nbpSeriesA2, String currency2) {

--- a/src/main/java/com/zpi/data/series/NbpSeriesB.java
+++ b/src/main/java/com/zpi/data/series/NbpSeriesB.java
@@ -27,16 +27,16 @@ public class NbpSeriesB {
         return rates;
     }
 
-    public static void analyzeStatisticalMeasures(NbpSeriesB nbpSeriesB) {
+    public static List<String> analyzeStatisticalMeasures(NbpSeriesB nbpSeriesB) {
         double[] valuesCurrency = getValuesCurrency(nbpSeriesB);
 
-        Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrency);
+        return Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrency);
     }
 
-    public static void analyzeSessions(NbpSeriesB nbpSeriesB) {
+    public static List<String> analyzeSessions(NbpSeriesB nbpSeriesB) {
         double[] valuesCurrency = getValuesCurrency(nbpSeriesB);
 
-        Methods.showResultsOfSessionAnalysis(valuesCurrency);
+        return Methods.showResultsOfSessionAnalysis(valuesCurrency);
     }
 
     public static void compareTwoCurrencies(NbpSeriesB nbpSeriesB1, String currency1, NbpSeriesB nbpSeriesB2, String currency2) {

--- a/src/main/java/com/zpi/data/series/NbpSeriesC.java
+++ b/src/main/java/com/zpi/data/series/NbpSeriesC.java
@@ -3,6 +3,7 @@ package com.zpi.data.series;
 import com.zpi.Methods;
 import com.zpi.data.rates.RatesForSeriesC;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class NbpSeriesC {
@@ -20,26 +21,36 @@ public class NbpSeriesC {
         return rates;
     }
 
-    public static void analyzeStatisticalMeasures(NbpSeriesC nbpSeriesC) {
+    public static List<String> analyzeStatisticalMeasures(NbpSeriesC nbpSeriesC) {
         double[] valuesCurrencyForBid = getValuesCurrencyForBid(nbpSeriesC);
         double[] valuesCurrencyForAsk = getValuesCurrencyForAsk(nbpSeriesC);
 
         System.out.println("\nCena sprzedaży");
-        Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrencyForBid);
+        List<String> listOne = Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrencyForBid);
 
         System.out.println("\nCena kupna");
-        Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrencyForAsk);
+        List<String> listTwo = Methods.showResultsOfStatisticalMeasuresAnalysis(valuesCurrencyForAsk);
+
+        List<String> newList = new ArrayList<String>(listOne);
+        newList.addAll(listTwo);
+
+        return newList;
     }
 
-    public static void analyzeSessions(NbpSeriesC nbpSeriesC) {
+    public static List<String> analyzeSessions(NbpSeriesC nbpSeriesC) {
         double[] valuesCurrencyForBid = getValuesCurrencyForBid(nbpSeriesC);
         double[] valuesCurrencyForAsk = getValuesCurrencyForAsk(nbpSeriesC);
 
         System.out.println("\nDla ceny kupna");
-        Methods.showResultsOfSessionAnalysis(valuesCurrencyForBid);
+        List<String> listOne = Methods.showResultsOfSessionAnalysis(valuesCurrencyForBid);
 
         System.out.println("\nDla ceny sprzedaży");
-        Methods.showResultsOfSessionAnalysis(valuesCurrencyForAsk);
+        List<String> listTwo =Methods.showResultsOfSessionAnalysis(valuesCurrencyForAsk);
+
+        List<String> newList = new ArrayList<String>(listOne);
+        newList.addAll(listTwo);
+
+        return newList;
     }
 
     public static void compareTwoCurrencies(NbpSeriesC nbpSeriesC1, String currency1, NbpSeriesC nbpSeriesC2, String currency2) {


### PR DESCRIPTION
Dodałem opcje zapisywania niektórych analiz, można zapisać analiz statystyczne oraz sesyjne dla tabel A,B,C,
nie ma opcji zapisywania danych dla analizy 3 porównywania walut, zapisywane są wyniki z krótkim opisem jaki typ analizy czy 1 czy 2, rodzaj tabeli, okres czy 1 czy 2 itd oraz jaka waluta, jedna waluta bo możliwy jest zapis 2 analiz 